### PR TITLE
Set type attribute for byte-compile warnings

### DIFF
--- a/highlight-stages.el
+++ b/highlight-stages.el
@@ -87,15 +87,19 @@ must be the expression matched.
 ESCAPE-MATCHER is a function with 1 parameter, LIMIT, which
 searches the next escaped expression. The function must return
 non-nil if succeeded, or nil otherwise. When the function returns
-non-nil, (match-string 0) must be the expression matched.")
+non-nil, (match-string 0) must be the expression matched."
+  :type 'alist
+  :group 'highlight-stages)
 
 (defcustom highlight-stages-highlight-real-quote t
   "If non-nil, \"real\" (not escapable) quotes are also
   highlighted."
+  :type 'boolean
   :group 'highlight-stages)
 
 (defcustom highlight-stages-highlight-priority 1
   "Priority which highlight overlays get."
+  :type 'integer
   :group 'highlight-stages)
 
 ;; + faces


### PR DESCRIPTION
Newer Emacs warns custom variables which does not set type attribute.

```
highlight-stages.el:52:1:Warning: defcustom for
    ‘highlight-stages-matcher-alist’ fails to specify type
highlight-stages.el:52:1:Warning: defcustom for
    ‘highlight-stages-matcher-alist’ fails to specify type
highlight-stages.el:92:1:Warning: defcustom for
    ‘highlight-stages-highlight-real-quote’ fails to specify type
highlight-stages.el:92:1:Warning: defcustom for
    ‘highlight-stages-highlight-real-quote’ fails to specify type
highlight-stages.el:97:1:Warning: defcustom for
    ‘highlight-stages-highlight-priority’ fails to specify type
highlight-stages.el:97:1:Warning: defcustom for
    ‘highlight-stages-highlight-priority’ fails to specify type
```
